### PR TITLE
Instance parameters (self) should be typed as ptr

### DIFF
--- a/gi-bindings-generator.opam
+++ b/gi-bindings-generator.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/cedlemo/OCaml-GI-ctypes-bindings-generator"
 bug-reports: "https://github.com/cedlemo/OCaml-GI-ctypes-bindings-generator/issues"
 license: "GPL3"
 dev-repo: "https://github.com/cedlemo/OCaml-GI-ctypes-bindings-generator.git"
-build: [["dune" "build" "-p" name "-j" jobs]]
+build: [["dune" "build" "-p" "gi-bindings-generator" "-j" jobs]]
 build-test: [["dune" "runtest" "-p" name "-j" jobs]]
 depends: [
   "dune" {build}

--- a/lib/Bind_object.ml
+++ b/lib/Bind_object.ml
@@ -57,7 +57,7 @@ let append_ctypes_object_methods_bindings object_name info sources skip_types =
     match Base_info.get_name bi with
     | None -> ()
     | Some n ->
-        let c = Some (object_name, "t", "t_typ") in
+        let c = Some (object_name, "t ptr", "ptr t_typ") in
         Bind_function.append_ctypes_function_bindings n mi c sources skip_types
   done
 


### PR DESCRIPTION
Since `t_typ` is a void pointer and all constructors (Eg ges_timeline_new) return pointer to the void ptr, self parameters should be `ptr t_typ` to match what it being returned from constructors.

This generates better bindings

```ml
open Ctypes                                                                  
open Foreign      
                                                                          
type t = unit ptr
let t_typ : t typ = ptr void                                                                              
                                                             
let create =                                                                  
  foreign "ges_timeline_new" (void @-> returning (ptr t_typ))            
let create_audio_video =                                                                       
  foreign "ges_timeline_new_audio_video" (void @-> returning (ptr t_typ))                                                    
let add_layer =             
  foreign "ges_timeline_add_layer" (ptr t_typ @-> ptr Layer.t_typ @-> returning (bool))
let add_track =                                                                                                   
  foreign "ges_timeline_add_track" (ptr t_typ @-> ptr Track.t_typ @-> returning (bool))
```

Previously it was

```ml
let add_layer =             
  foreign "ges_timeline_add_layer" (t_typ @-> ptr Layer.t_typ @-> returning (bool))
```
which needed to be cast before it was usable.